### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.1
+
+orbs:
+  python: circleci/python@0.2.1
+
+jobs:
+  build-and-test:
+    resource_class: small
+    executor: python/default
+    steps:
+      - checkout
+      - python/load-cache
+      - python/install-deps
+      - python/save-cache
+      - run:
+          name: Test
+          command: | 
+            python -m flake8
+            python manage.py test
+
+workflows:
+  main:
+    jobs:
+      - build-and-test


### PR DESCRIPTION
## Objectif

CircleCI permet de lancer les tests à chaque commit et/ou PR.

## Détails

Permet de s'assurer de la qualité du code de l'application.

Bizarrement `flake8` seul renvoie une erreur, donc j'ai du mettre `python -m flake8`, sans être vraiment sûr si cela fonctionne.