### PR TITLE
Ajustements cosmétiques de l'interface

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -203,6 +203,10 @@ form .form-group {
 }
 .card-body {
   padding: 10px;
+
+  button {
+    margin-top: 0 !important;
+  }
 }
 .card-footer {
   background-color: inherit; // avoir grey on grey
@@ -210,10 +214,13 @@ form .form-group {
 
 /* Global css */
 
-/* adds a 'opens in new tab' icon */
+/* adds a 'opens in new tab' icon. but not for images */
 a[target="_blank"]::after {
   content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
   margin: 0 3px 0 5px;
+}
+a[href$=".jpg"]::after, a[href$=".jpeg"]::after, a[href$=".png"]::after {
+  display: none;
 }
 
 a.no-decoration {
@@ -250,11 +257,17 @@ a.no-decoration {
   margin-left: 10px;
   margin-right: 10px;
 }
+.margin-left-20 {
+  margin-left: 20px;
+}
 .margin-bottom-0 {
   margin-bottom: 0;
 }
 .margin-bottom-10 {
   margin-bottom: 10px;
+}
+.margin-bottom-1em {
+  margin-bottom: 1em;
 }
 .padding-10 {
   padding: 10px;

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -42,6 +42,15 @@ header > div {
   padding: 5px;
 }
 
+header > div > h1 {
+  margin: 0;
+}
+
+header > div > h2 {
+  margin-top: 5px;
+  margin-bottom: 0;
+}
+
 @media(hover: hover) and (pointer: fine) {
   header h1 a:hover {
     text-shadow: 0px 0px 1px var(--primary);

--- a/frontend/src/components/QuestionAnswerCards.vue
+++ b/frontend/src/components/QuestionAnswerCards.vue
@@ -16,7 +16,7 @@
         <!-- Question text -->
         <div class="row no-gutters justify-content-center">
           <div class="col-md-10 col-lg-8">
-            <h3 v-html="$options.filters.abbr(question.text, glossaire)"></h3>
+            <h3 v-html="$options.filters.abbr(questionTextWithLineBreaks, glossaire)"></h3>
           </div>
         </div>
         <!-- Question answer choices -->
@@ -73,9 +73,7 @@
         <div class="col-sm-auto">
           <p title="Explication">
             <span>ℹ️&nbsp;</span>
-            <template v-for="answer_explanation_line in question.answer_explanation.split('\n')">
-              <span :key="answer_explanation_line">{{ answer_explanation_line }}<br /></span>
-            </template>
+            <span v-html="questionAnswerExplanationWithLineBreaks"></span>
           </p>
         </div>
       </div>
@@ -149,6 +147,12 @@ export default {
   computed: {
     glossaire() {
       return this.$store.state.ressources.glossaire;
+    },
+    questionTextWithLineBreaks() {
+      return this.question.text.replaceAll('\n', '<br />');
+    },
+    questionAnswerExplanationWithLineBreaks() {
+      return this.question.answer_explanation.replaceAll('\n', '<br />');
     },
   },
 

--- a/frontend/src/components/QuestionAnswerCards.vue
+++ b/frontend/src/components/QuestionAnswerCards.vue
@@ -101,14 +101,14 @@
 
       <!-- Extra info -->
       <div class="row no-gutters small">
-        <div class="col" v-if="question.tags && question.tags.length > 0" title="Tag(s) de la question">
+        <div class="col-sm" title="Auteur de la question">
+          📝&nbsp;Auteur<span class="label label-hidden"><strong>{{ question.author }}</strong></span>
+        </div>
+        <div class="col-sm" v-if="question.tags && question.tags.length > 0" title="Tag(s) de la question">
           <!-- 🏷️&nbsp;Tag<span v-if="question.tags.length > 1">s</span>:&nbsp;{{ question.tags.map(t => t.name).join(', ') }} -->
           🏷️&nbsp;<span v-for="tag in question.tags" :key="tag.id">
             <span class="label label-tag">{{ tag.name }}</span>
           </span>
-        </div>
-        <div  class="col">
-          <div class="label label-hidden" title="Auteur de la question">📝&nbsp;Auteur:&nbsp;{{ question.author }}</div>
         </div>
         <!-- <div title="Statistiques de la question">📊&nbsp;Stats:&nbsp;{{ question.answer_success_count_agg }} / {{ question.answer_count_agg }} ({{ question.answer_success_rate }}%)</div> -->
       </div>

--- a/frontend/src/components/QuizCard.vue
+++ b/frontend/src/components/QuizCard.vue
@@ -1,31 +1,24 @@
 <template>
-  <section>
-    <router-link class="card no-decoration" :to="{ name: 'quiz-detail', params: { quizId: quiz.id } }">
-      <img class="card-img-top" v-bind:src="quiz.image_background_url || 'https://showyourstripes.info/stripes/GLOBE---1850-2019-MO.png'" alt="Une image pour illustrer le quiz">
-      <div class="card-body">
-        <h2 class="card-title">{{ quiz.name }}</h2>
-        <p class="card-subtitle"><strong>{{ quiz.questions.length }}</strong> question<span v-if="quiz.questions.length > 1">s</span></p>
-        <button class="btn btn-outline-primary btn-lg btn-block">Découvrir le quiz</button>
-        <section class="d-none d-md-block">
-          <hr class="margin-top-bottom-10" />
-          <div class="small">
-            <div class="label label-hidden">📝&nbsp;Auteur:&nbsp;<strong>{{ quiz.author }}</strong></div>
-            <!-- <div v-if="quiz.categories_list && quiz.categories_list.length > 0" title="Catégorie(s) du quiz">
-              📂
-              <span v-for="(category, index) in quiz.categories_list" :key="category">
-                <span v-if="index < 3" class="label label-category">{{ category }}</span>
-              </span>
-            </div> -->
-            <!-- <div v-if="quiz.tags && quiz.tags.length > 0" title="Tag(s) du quiz">
-              🏷️&nbsp;<span v-for="(tag, index) in quiz.tags" :key="tag">
-                <span v-if="index < 3" class="label label-tag">{{ tag.name }}</span>
-              </span>
-            </div> -->
-          </div>
-        </section>
-      </div>
-    </router-link>
-  </section>
+  <router-link class="card no-decoration" :to="{ name: 'quiz-detail', params: { quizId: quiz.id } }">
+    <img class="card-img-top" v-bind:src="quiz.image_background_url || 'https://showyourstripes.info/stripes/GLOBE---1850-2019-MO.png'" alt="Une image pour illustrer le quiz">
+    <div class="card-body">
+      <h2 class="card-title">{{ quiz.name }}</h2>
+      <p class="card-text text-center">
+        <strong>{{ quiz.questions.length }}</strong> question<span v-if="quiz.questions.length > 1">s</span>
+        <button class="btn btn-outline-primary btn-sm margin-0 margin-left-20">Découvrir</button>
+      </p>
+      <!-- <button class="btn btn-outline-primary btn-lg btn-block">Découvrir le quiz</button> -->
+      <!-- <section class="d-none d-md-block">
+        <hr class="margin-top-bottom-10" />
+        <div class="small">
+          <div class="label label-hidden">📝&nbsp;Auteur&nbsp;<strong>{{ quiz.author }}</strong></div>
+        </div>
+      </section> -->
+    </div>
+    <div class="card-footer small d-none d-md-block">
+      📝&nbsp;Auteur<span class="label label-hidden"><strong>{{ quiz.author }}</strong></span>
+    </div>
+  </router-link>
 </template>
 <script>
 

--- a/frontend/src/components/QuizCard.vue
+++ b/frontend/src/components/QuizCard.vue
@@ -7,13 +7,6 @@
         <strong>{{ quiz.questions.length }}</strong> question<span v-if="quiz.questions.length > 1">s</span>
         <button class="btn btn-outline-primary btn-sm margin-0 margin-left-20">Découvrir</button>
       </p>
-      <!-- <button class="btn btn-outline-primary btn-lg btn-block">Découvrir le quiz</button> -->
-      <!-- <section class="d-none d-md-block">
-        <hr class="margin-top-bottom-10" />
-        <div class="small">
-          <div class="label label-hidden">📝&nbsp;Auteur&nbsp;<strong>{{ quiz.author }}</strong></div>
-        </div>
-      </section> -->
     </div>
     <div class="card-footer small d-none d-md-block">
       📝&nbsp;Auteur<span class="label label-hidden"><strong>{{ quiz.author }}</strong></span>

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -1,18 +1,13 @@
 <template>
   <section>
 
-    <div v-if="quizzes && quizzes.length > 0" id="quiz-list"  class="row">
-      <div class="col-sm-4" v-for="quiz in quizzes" :key="quiz.id">
-        <QuizCard :quiz="quiz"/>
+    <div v-if="quizzes && quizzes.length > 0" id="quiz-list" class="margin-bottom-1em">
+      <div class="card-deck">
+        <QuizCard v-for="quiz in quizzes" :key="quiz.id" :quiz="quiz"/>
       </div>
-        <!-- <div class="col-sm">
-          <router-link class="no-decoration" :to="{ name: 'quiz-detail', params: { quizId: quiz.id, skipIntro: true } }">
-            <button class="btn btn-outline-primary">⏩&nbsp;Commencer le quiz !</button>
-          </router-link>
-        </div> -->
     </div>
 
-    <div class="row justify-content-md-center">
+    <div class="row justify-content-md-center margin-bottom-1em">
       <div class="col-sm-6" v-if="questionsCount">
         <router-link class="no-decoration" :to="{ name: 'quiz-list' }">
           <button class="btn btn-primary btn-lg btn-block">
@@ -231,10 +226,6 @@ svg {
 }
 .jumbotron .row .col:hover {
   transform: scale(1.03);
-}
-
-.row > .col-sm-6,.col-sm-4{
-  padding-bottom: 20px;
 }
 
 .btn-lg {

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -1,9 +1,9 @@
 <template>
   <section>
 
-    <div v-if="quizzes && quizzes.length > 0" id="quiz-list" class="margin-bottom-1em">
-      <div class="card-deck">
-        <QuizCard v-for="quiz in quizzes" :key="quiz.id" :quiz="quiz"/>
+    <div class="row" v-if="quizzes && quizzes.length > 0" id="quiz-list">
+      <div class="col-sm-4" v-for="quiz in quizzes" :key="quiz.id">
+        <QuizCard :quiz="quiz"/>
       </div>
     </div>
 
@@ -230,5 +230,12 @@ svg {
 
 .btn-lg {
   min-height: 75px;
+}
+
+.row > .col-sm-4 {
+  padding-bottom: 15px;
+}
+.row > .col-sm-4 > .card {
+  height: 100%;
 }
 </style>

--- a/frontend/src/views/QuizDetailPage.vue
+++ b/frontend/src/views/QuizDetailPage.vue
@@ -14,7 +14,7 @@
           <hr class="margin-top-bottom-10" />
 
           <div class="row no-gutters small">
-            <div class="col" title="Nombre de question">
+            <div class="col" title="Nombre de questions">
               ❓&nbsp;<span class="label label-hidden"><strong>{{ quiz.questions.length }}</strong></span>Questions
             </div>
             <div class="col" title="Difficulté">

--- a/frontend/src/views/QuizListPage.vue
+++ b/frontend/src/views/QuizListPage.vue
@@ -68,4 +68,7 @@ export default {
 .row > .col-sm-6 {
   padding-bottom: 15px;
 }
+.row > .col-sm-6 > .card {
+  height: 100%;
+}
 </style>


### PR DESCRIPTION
Modifications apportées : 
- Header : réduction du padding dans le titre (pour avoir d'avantage de contenu d'affiché)
- QuizCard : réduction de la taille du bouton (pour avoir d'avantage de contenu d'affiché) (sachant que cliquer sur le bouton ou la carte complète revient au même)
- Questions :
  - meilleure gestion des sauts de ligne pour les champs `text` & `answer_explanation`
  - cache l'icône "lien s'ouvrira dans un autre onglet" pour les images


Avant / Après : 

<div>
<img width="49%" alt="Screenshot 2020-12-01 at 09 39 57" src="https://user-images.githubusercontent.com/7147385/100716926-a7ac8600-33b9-11eb-83a5-293f2f3c7f51.png">
<img width="49%" alt="Screenshot 2020-12-01 at 09 40 41" src="https://user-images.githubusercontent.com/7147385/100716942-b004c100-33b9-11eb-8f9f-222926d0ca1d.png">
</div>

<div>
<img width="49%" alt="Screenshot 2020-12-01 at 09 41 46" src="https://user-images.githubusercontent.com/7147385/100717006-c90d7200-33b9-11eb-8661-79e295ecdb19.png">
<img width="49%" alt="Screenshot 2020-12-01 at 09 41 57" src="https://user-images.githubusercontent.com/7147385/100717031-ce6abc80-33b9-11eb-972f-875264b311c3.png">
</div>
