### PR TITLE
Automatiser les tâches récurrentes grâce à Github Actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ SECURE_SSL_REDIRECT = False # True in prod
 
 # Github API
 GITHUB_ACCESS_TOKEN = ""
+GITHUB_CRON_ACTION_TOKEN = ""
 
 # Notion.so (notion-py)
 NOTION_TOKEN_V2 = ""

--- a/.github/workflows/cron_aggregate_stats.yml
+++ b/.github/workflows/cron_aggregate_stats.yml
@@ -1,4 +1,4 @@
-name: Cron
+name: cron_aggregate_stats
 
 # Controls when the action will run. 
 on:

--- a/.github/workflows/cron_export_data_to_github.yaml
+++ b/.github/workflows/cron_export_data_to_github.yaml
@@ -1,17 +1,17 @@
-name: cron_aggregate_stats
+name: cron_export_data_to_github
 
 # Controls when the action will run. 
 on:
   schedule:
-    # Every 6 hours (4 times a day: 00:15, 06:15, 12:15, 18:15)
-    - cron: '15 */6 * * *'
+    # Every 12 hours (2 times a day: 00:30, 12:30)
+    - cron: '30 */12 * * *'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  aggregate_stats:
+  export_data_to_github:
     runs-on: ubuntu-latest
     steps:
-      - run: curl -X "GET" "${{ secrets.BACKEND_URL }}/actions/aggregate-stats?token=${{ secrets.CRON_GITHUB_ACTION_SECRET }}"
+      - run: curl -X "GET" "${{ secrets.BACKEND_URL }}/actions/export-data-to-github?token=${{ secrets.CRON_GITHUB_ACTION_SECRET }}"

--- a/.github/workflows/cron_import_questions_from_notion.yaml
+++ b/.github/workflows/cron_import_questions_from_notion.yaml
@@ -1,17 +1,17 @@
-name: cron_aggregate_stats
+name: cron_import_questions_from_notion
 
 # Controls when the action will run. 
 on:
   schedule:
-    # Every 6 hours (4 times a day)
-    - cron: '0 */6 * * *'
+    # Every 12 hours (2 times a day)
+    - cron: '0 */12 * * *'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  aggregate_stats:
+  import_questions_from_notion:
     runs-on: ubuntu-latest
     steps:
-      - run: curl -X "GET" "${{ secrets.BACKEND_URL }}/actions/aggregate-stats?token=${{ secrets.CRON_GITHUB_ACTION_SECRET }}"
+      - run: curl -X "GET" "${{ secrets.BACKEND_URL }}/actions/import-questions-from-notion?token=${{ secrets.CRON_GITHUB_ACTION_SECRET }}"

--- a/.github/workflows/cron_import_questions_from_notion.yaml
+++ b/.github/workflows/cron_import_questions_from_notion.yaml
@@ -3,7 +3,7 @@ name: cron_import_questions_from_notion
 # Controls when the action will run. 
 on:
   schedule:
-    # Every 12 hours (2 times a day)
+    # Every 12 hours (2 times a day: 00:00, 12:00)
     - cron: '0 */12 * * *'
 
   # Allows you to run this workflow manually from the Actions tab

--- a/api/admin.py
+++ b/api/admin.py
@@ -331,22 +331,37 @@ class QuestionAdmin(ImportMixin, ExportMixin, admin.ModelAdmin):
         Corresponding template in templates/admin/api/question/change_list_with_import.html
         """
 
-        notion_questions_validation = []
+        configuration = Configuration.get_solo()
+        notion_questions_import_scope_choices = [
+            (
+                scope_value,
+                scope_label,
+                "notion_questions_scope_" + str(scope_value) + "_last_imported",
+            )
+            for (
+                scope_value,
+                scope_label,
+            ) in constants.NOTION_QUESTIONS_IMPORT_SCOPE_CHOICES[1:]
+        ]
+        notion_questions_import_response = []
 
         if request.POST.get("run_import_questions_from_notion_script", False):
             out = StringIO()
             scope = request.POST.get("run_import_questions_from_notion_script")
             management.call_command("import_questions_from_notion", scope, stdout=out)
-            notion_questions_validation = out.getvalue()
-            notion_questions_validation = notion_questions_validation.split("\n")
-            notion_questions_validation = [
+            notion_questions_import_response = out.getvalue()
+            notion_questions_import_response = notion_questions_import_response.split(
+                "\n"
+            )
+            notion_questions_import_response = [
                 elem.split("///") if ("///" in elem) else elem
-                for elem in notion_questions_validation
+                for elem in notion_questions_import_response
             ]
 
         extra_context = extra_context or {
-            "configuration": Configuration.get_solo(),
-            "notion_questions_validation": notion_questions_validation,
+            "configuration": configuration,
+            "notion_questions_import_scope_choices": notion_questions_import_scope_choices,
+            "notion_questions_import_response": notion_questions_import_response,
         }
 
         # Call the superclass changelist_view to render the page

--- a/api/constants.py
+++ b/api/constants.py
@@ -94,6 +94,17 @@ CONTRIBUTION_TYPE_LIST = [
     "nom application",
 ]
 
+NOTION_QUESTIONS_IMPORT_SCOPE_CHOICES = [
+    (0, "tout"),
+    (1, "1 à 200"),
+    (2, "200 à 400"),
+    (3, "400 à 600"),
+    (4, "600 et plus"),
+]
+NOTION_QUESTIONS_IMPORT_SCOPE_LIST = [
+    value for (value, label) in NOTION_QUESTIONS_IMPORT_SCOPE_CHOICES
+]
+
 
 def daily_stat_hour_split_jsonfield_default_value():
     return DEFAULT_DAILY_STAT_HOUR_SPLIT

--- a/api/management/commands/import_questions_from_notion.py
+++ b/api/management/commands/import_questions_from_notion.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         scope = options["scope"]
-        print(scope)
+
         notion_questions_list = []
         questions_ids_duplicate = []
         questions_ids_missing = []

--- a/api/templates/admin/api/question/change_list_with_import.html
+++ b/api/templates/admin/api/question/change_list_with_import.html
@@ -1,7 +1,8 @@
 {% extends "admin/change_list.html" %}
 
 {% load static %}
-{% load isinstance %}
+
+{% load custom_filters %}
 
 {% block extrahead %}
 {{ block.super }}
@@ -49,62 +50,22 @@
       </tr>
     </thead>
     <tbody>
-      <form method="POST">
-        {% csrf_token %}
-        <input type="hidden" name="run_import_questions_from_notion_script" value="1" />
-        <tr>
-          <td>
-            <input class="action-button" type="submit" value="Lancer l'import des questions : # 1 à 200">
-          </td>
-          <td>
-            <strong>{{ configuration.notion_questions_scope_1_last_imported | date:"SHORT_DATETIME_FORMAT" }}</strong>
-            <br />
-            <span>({{ configuration.notion_questions_scope_1_last_imported | timesince }} ago)</span>
-          </td>
-        </tr>
-      </form>
-      <form method="POST">
-        {% csrf_token %}
-        <input type="hidden" name="run_import_questions_from_notion_script" value="2" />
-        <tr>
-          <td>
-            <input class="action-button" type="submit" value="Lancer l'import des questions : # 200 à 400">
-          </td>
-          <td>
-            <strong>{{ configuration.notion_questions_scope_2_last_imported | date:"SHORT_DATETIME_FORMAT" }}</strong>
-            <br />
-            <span>({{ configuration.notion_questions_scope_2_last_imported | timesince }} ago)</span>
-          </td>
-        </tr>
-      </form>
-      <form method="POST">
-        {% csrf_token %}
-        <input type="hidden" name="run_import_questions_from_notion_script" value="3" />
-        <tr>
-          <td>
-            <input class="action-button" type="submit" value="Lancer l'import des questions : # 400 à 600">
-          </td>
-          <td>
-            <strong>{{ configuration.notion_questions_scope_3_last_imported | date:"SHORT_DATETIME_FORMAT" }}</strong>
-            <br />
-            <span>({{ configuration.notion_questions_scope_3_last_imported | timesince }} ago)</span>
-          </td>
-        </tr>
-      </form>
-      <form method="POST">
-        {% csrf_token %}
-        <input type="hidden" name="run_import_questions_from_notion_script" value="4" />
-        <tr>
-          <td>
-            <input class="action-button" type="submit" value="Lancer l'import des questions : # 600 et plus">
-          </td>
-          <td>
-            <strong>{{ configuration.notion_questions_scope_4_last_imported | date:"SHORT_DATETIME_FORMAT" }}</strong>
-            <br />
-            <span>({{ configuration.notion_questions_scope_4_last_imported | timesince }} ago)</span>
-          </td>
-        </tr>
-      </form>
+      {% for scope_value, scope_label, configuration_scope_field in notion_questions_import_scope_choices %}
+        <form method="POST">
+          {% csrf_token %}
+          <input type="hidden" name="run_import_questions_from_notion_script" value="{{ scope_value }}" />
+          <tr>
+            <td>
+              <input class="action-button" type="submit" value="Lancer l'import des questions : # {{ scope_label }}">
+            </td>
+            <td>
+              <strong>{{ configuration | get_obj_attr:configuration_scope_field | date:"SHORT_DATETIME_FORMAT" }}</strong>
+              <br />
+              <span>({{ configuration | get_obj_attr:configuration_scope_field | timesince }} ago)</span>
+            </td>
+          </tr>
+        </form>
+      {% endfor %}
     </tbody>
   </table>
 
@@ -112,11 +73,11 @@
   <div id="spinner" class="loading" role="status" style="display:none"></div>
 </section>
 
-{% if notion_questions_validation %}
+{% if notion_questions_import_response %}
 <section id="result-section">
   <h2>Résultats : </h2>
   <ul>
-  {% for result in notion_questions_validation %}
+  {% for result in notion_questions_import_response %}
     {% if result|isinstance:"list" %}
       <li>
         <ul>

--- a/api/templatetags/custom_filters.py
+++ b/api/templatetags/custom_filters.py
@@ -6,3 +6,8 @@ register = template.Library()
 @register.filter(name="isinstance")
 def isinstance_filter(val, instance_type):
     return isinstance(val, eval(instance_type))
+
+
+@register.filter(name="get_obj_attr")
+def get_obj_attr_filter(obj, key):
+    return getattr(obj, key)

--- a/api/views.py
+++ b/api/views.py
@@ -326,12 +326,6 @@ def quiz_detail_answer_event(request, pk):
             answer_success_count=request.data["answer_success_count"],
         )
 
-        # Temporary hack to regularly cleanup Question stats
-        # TODO: find a better solution !
-        question_answer_event_count = QuestionAnswerEvent.objects.count()
-        if question_answer_event_count > 900:
-            management.call_command("generate_daily_stats")
-
         serializer = QuizAnswerEventSerializer(quiz_answer_event)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -166,7 +166,7 @@ IMPORT_EXPORT_SKIP_ADMIN_LOG = True
 
 SHELL_PLUS_IMPORTS = [
     "from datetime import datetime, timedelta",
-    "from api import utilities_notion",
+    "from api import constants, utilities, utilities_notion, utilities_github",
 ]
 
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -166,14 +166,14 @@ IMPORT_EXPORT_SKIP_ADMIN_LOG = True
 
 SHELL_PLUS_IMPORTS = [
     "from datetime import datetime, timedelta",
-    "from api import constants, utilities, utilities_notion, utilities_github",
+    "from api import constants, utilities, utilities_stats, utilities_notion, utilities_github",
 ]
 
 
 # Github
 
 GITHUB_ACCESS_TOKEN = os.getenv("GITHUB_ACCESS_TOKEN")
-
+GITHUB_CRON_ACTION_TOKEN = os.getenv("GITHUB_CRON_ACTION_TOKEN")
 
 # Notion.so
 

--- a/app/urls.py
+++ b/app/urls.py
@@ -13,4 +13,5 @@ urlpatterns = [
         "actions/import-questions-from-notion",
         views.action_import_questions_from_notion,
     ),
+    path("actions/export-data-to-github", views.action_import_questions_from_notion,),
 ]

--- a/app/urls.py
+++ b/app/urls.py
@@ -9,4 +9,8 @@ urlpatterns = [
     path("admin/", admin_site.urls),
     path("api/", include("api.urls")),
     path("actions/aggregate-stats", views.action_aggregate_stats),
+    path(
+        "actions/import-questions-from-notion",
+        views.action_import_questions_from_notion,
+    ),
 ]

--- a/app/urls.py
+++ b/app/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path("", views.app_home),
     path("admin/", admin_site.urls),
     path("api/", include("api.urls")),
+    path("actions/aggregate-stats", views.action_aggregate_stats),
 ]

--- a/app/views.py
+++ b/app/views.py
@@ -37,3 +37,16 @@ def action_import_questions_from_notion(request):
     management.call_command("import_questions_from_notion", scope=0)
 
     return HttpResponse("success")
+
+
+@require_http_methods(["GET"])
+def action_export_data_to_github(request):
+    """
+    Run the export command
+    """
+    if not request.GET.get("token") == settings.GITHUB_CRON_ACTION_TOKEN:
+        return HttpResponseForbidden()
+
+    management.call_command("action_export_data_to_github")
+
+    return HttpResponse("success")

--- a/app/views.py
+++ b/app/views.py
@@ -24,3 +24,16 @@ def action_aggregate_stats(request):
     management.call_command("generate_daily_stats")
 
     return HttpResponse("success")
+
+
+@require_http_methods(["GET"])
+def action_import_questions_from_notion(request):
+    """
+    Run the import command
+    """
+    if not request.GET.get("token") == settings.GITHUB_CRON_ACTION_TOKEN:
+        return HttpResponseForbidden()
+
+    management.call_command("import_questions_from_notion", scope=0)
+
+    return HttpResponse("success")

--- a/app/views.py
+++ b/app/views.py
@@ -1,4 +1,7 @@
-from django.http import HttpResponse
+from django.conf import settings
+from django.core import management
+from django.http import HttpResponse, HttpResponseForbidden
+from django.views.decorators.http import require_http_methods
 
 
 def app_home(request):
@@ -8,3 +11,16 @@ def app_home(request):
         <p>The api is available at /api</p>
     """
     )
+
+
+@require_http_methods(["GET"])
+def action_aggregate_stats(request):
+    """
+    Run the daily_stats aggregation command
+    """
+    if not request.GET.get("token") == settings.GITHUB_CRON_ACTION_TOKEN:
+        return HttpResponseForbidden()
+
+    management.call_command("generate_daily_stats")
+
+    return HttpResponse("success")


### PR DESCRIPTION
Issue https://github.com/raphodn/know-your-planet/issues/164

Modifications apportées : 
- ajout de 3 nouveaux "Github actions workflow"
- ajout de 3 endpoints dans le backend
- l'authentification se fait avec un token passé en paramètre des requêtes
- les fréquences pourront être ajustées

|Action|Endpoint|Management command|Fréquence|
|-|-|-|-|
|Aggréger les stats|`/actions/aggregate-stats`|`generate_daily_stats.py`|Toutes les 6 heures|
|Importer les questions depuis Notion|`/actions/import-questions-from-notion`|`import_questions_from_notion.py`|2 fois par jour|
|Exporter la donnée vers Github|`/actions/export-data-to-github`|`export_data_to_github.py`|2 fois par jour|