### PR TITLE
Fixes #166

### DIFF
--- a/frontend/_redirects
+++ b/frontend/_redirects
@@ -1,2 +1,0 @@
-# https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file
-/api/* https://quiz-anthropocene.osc-fr1.scalingo.io/api

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -8,7 +8,6 @@
 /a-propos /a-propos.rendered.html 200
 /contribuer /contribuer.rendered.html 200
 /glossaire /glossaire.rendered.html 200
-/test /a-propos.rendered.html 200
 
 # Keep this at the bottom - settings for SPA routing
 # index.vue.html is used because Netlify automatically uses index.html if present, and that breaks the index's prerendering

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,2 +1,15 @@
-# Netlify settings for single-page application
-/*    /index.html   200
+# https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file
+
+# API
+/api/* https://quiz-anthropocene.osc-fr1.scalingo.io/api
+
+# Use prerender page when available (see vue.config.js)
+/ /index.rendered.html 200
+/a-propos /a-propos.rendered.html 200
+/contribuer /contribuer.rendered.html 200
+/glossaire /glossaire.rendered.html 200
+/test /a-propos.rendered.html 200
+
+# Keep this at the bottom - settings for SPA routing
+# index.vue.html is used because Netlify automatically uses index.html if present, and that breaks the index's prerendering
+/* /index.vue.html 200

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -5,6 +5,7 @@ const path = require('path');
 
 module.exports = {
   lintOnSave: true, // 'default' makes compilation fail in case of errors
+  indexPath: 'index.vue.html',
   configureWebpack: (config) => {
     if (process.env.NODE_ENV !== 'production') return;
     return {
@@ -12,15 +13,22 @@ module.exports = {
         new PrerenderSpaPlugin({
           // Required - The path to the webpack-outputted app to prerender.
           staticDir: path.join(__dirname, 'dist'),
+
           // Required - Routes to render.
+          // If you add routes here, don't forget to edit the public/_redirects file
           routes: [
             '/',
             '/a-propos', '/contribuer', '/glossaire',
             // '/quiz',
           ],
-          // Optional - default None
-          // renderAfterTime: 5000, // 5 seconds
-          // renderAfterDocumentEvent: 'custom-render-trigger'
+          postProcess (renderedRoute) {
+            if (renderedRoute.originalRoute === '/') {
+              renderedRoute.route = '/index';
+            }
+
+            renderedRoute.outputPath = path.join(__dirname, 'dist', renderedRoute.route + '.rendered.html');
+            return renderedRoute
+          },
         }),
       ],
     };

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -21,13 +21,12 @@ module.exports = {
             '/a-propos', '/contribuer', '/glossaire',
             // '/quiz',
           ],
-          postProcess (renderedRoute) {
+          postProcess(renderedRoute) {
             if (renderedRoute.originalRoute === '/') {
               renderedRoute.route = '/index';
             }
-
             renderedRoute.outputPath = path.join(__dirname, 'dist', renderedRoute.route + '.rendered.html');
-            return renderedRoute
+            return renderedRoute;
           },
         }),
       ],


### PR DESCRIPTION
- Génération des fichiers prerender avec un nom deterministique et évident : `<page>.rendered.html`. 
- Génération de l'`index.html` de Vue avec un nom différent pour éviter d'avoir un fichier `index.html` "par défaut" : `index.vue.html`.
- Réécriture des règles de redirection Netlify pour utiliser le prerender quand c'est possible et fallback sur l'index de Vue.

Je pense que c'est améliorable mais je n'ai pas trop d'idées de comment. Peut-être garder le système de dossier style `a-propos/index.html` et uniquement faire la différence avec `index.rendered.html` et `index.vue.html` ?